### PR TITLE
Fix filesystem tests on linux

### DIFF
--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -56,6 +56,7 @@ namespace Vostok.Logging.File.Configuration
         /// <summary>
         /// <para>Specifies the way to share log file.</para>
         /// <para>Dynamic reconfiguration is not supported for this parameter.</para>
+        /// <para>Note that this parameter does not work as expected on Unix systems. See https://github.com/dotnet/runtime/issues/34126.</para>
         /// </summary>
         public FileShare FileShare { get; set; } = FileShare.Read;
 

--- a/Vostok.Logging.File/Helpers/FileSystem.cs
+++ b/Vostok.Logging.File/Helpers/FileSystem.cs
@@ -63,8 +63,6 @@ namespace Vostok.Logging.File.Helpers
         {
             string ReplaceSlashes(string value) => value.Replace('\\', '/').Replace('/', '_');
 
-            FileStream CreateFileStream(FileMode fileMode) => new FileStream(file.NormalizedPath, fileMode, FileAccess.Write, settings.FileShare, 1);
-
             // NOTE: See https://docs.microsoft.com/en-us/dotnet/api/system.threading.mutex to understand naming.
             string CreateMutexName() => $"Global\\{ReplaceSlashes(file.NormalizedPath)}-FileLogMutex";
 
@@ -100,6 +98,8 @@ namespace Vostok.Logging.File.Helpers
 
                 throw new Exception("Unable to open file.");
             }
+
+            FileStream CreateFileStream(FileMode fileMode) => new FileStream(file.NormalizedPath, fileMode, FileAccess.Write, settings.FileShare, 1);
 
             try
             {

--- a/Vostok.Logging.File/Helpers/FileSystem.cs
+++ b/Vostok.Logging.File/Helpers/FileSystem.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Vostok.Logging.File.Configuration;
 
 namespace Vostok.Logging.File.Helpers
@@ -73,6 +72,7 @@ namespace Vostok.Logging.File.Helpers
                 {
                     // NOTE: See https://github.com/dotnet/runtime/issues/34126
                     // In order to avoid multiple writers, we want to fall in case file is opened either for reading or writing.
+                    // There is a race condition currently and it's still possible that multiple processes may write to the same file.
                     using (new FileStream(file.NormalizedPath, fileMode, FileAccess.Write, FileShare.None, 1)){}
                 }
                 


### PR DESCRIPTION
Unfortunately, we can't rely on unix `flock` mechanism, because it is only advisory. 
In addition, it does not use such granular access system like win locks. It only uses shared/exclusive locks.

Proposed solution: since we don't want to have concurrent writers and since we always want to be able to concurrently read log, we should maintain shared lock, not exclusive. 
The problem is that we can't distinguish writers and readers. We can only see if any lock is taken (through taking exclusive lock by specifying `FileShare.None`)

So let's just pessimistically assume that if we see any lock - then this file is used by writer. 

Since we can't atomically change exclusive lock to shared one and we want to avoid race conditions, we should both check and acquire locks under global mutex.