### PR TITLE
Refresh settings

### DIFF
--- a/Vostok.Logging.File.Tests/Functional/FileLogFunctionalTestsBase.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLogFunctionalTestsBase.cs
@@ -49,6 +49,11 @@ namespace Vostok.Logging.File.Tests.Functional
             System.IO.File.ReadAllText(fileName.NormalizedPath).Should().ContainAll(messages);
         }
         
+        protected static void ShouldNotContainMessages(FilePath fileName, IEnumerable<string> messages)
+        {
+            System.IO.File.ReadAllText(fileName.NormalizedPath).Should().NotContainAny(messages);
+        }
+        
         protected static void ShouldContainMessage(FilePath fileName, string message)
         {
             ShouldContainMessages(fileName, new []{message});

--- a/Vostok.Logging.File.Tests/Functional/FileLog_CacheAndFlush_Tests.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLog_CacheAndFlush_Tests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using NUnit.Framework;
+using Vostok.Commons.Testing;
+using Vostok.Logging.File.Configuration;
+using Vostok.Logging.Formatting;
+
+// ReSharper disable AccessToModifiedClosure
+
+namespace Vostok.Logging.File.Tests.Functional
+{
+    [TestFixture]
+    internal class FileLog_CacheAndFlush_Tests : FileLogFunctionalTestsBase
+    {
+        // TODO: Propagate EnableCache in all tests
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_write_to_new_file_after_settings_update(bool cache)
+        {
+            var firstLog = Folder.GetFileName("firstLog");
+            var secondLog = Folder.GetFileName("secondLog");
+
+            var firstLogMessages = GenerateMessages(0, 3);
+            var secondLogMessages = GenerateMessages(3, 6);
+
+            var currentSettings = new FileLogSettings {FilePath = firstLog};
+
+            using (var log = new FileLog(() => currentSettings))
+            {
+                WriteMessagesWithTimeout(log, firstLogMessages, 0);
+
+                currentSettings = new FileLogSettings {FilePath = secondLog};
+                FileLog.RefreshAllSettings();
+
+                WriteMessagesWithTimeout(log, secondLogMessages, 0);
+            }
+
+            ShouldContainMessages(firstLog, firstLogMessages);
+            ShouldContainMessages(secondLog, secondLogMessages);
+        }
+
+        [Test]
+        public void Should_respect_writer_setting_updates()
+        {
+            var logFile = Folder.GetFileName("firstLog");
+
+            var firstMessages = GenerateMessages(0, 3);
+            var secondMessages = GenerateMessages(3, 6);
+
+            var currentSettings = new FileLogSettings {FilePath = logFile};
+
+            using (var log = new FileLog(() => currentSettings))
+            {
+                WriteMessagesWithTimeout(log, firstMessages, 0);
+
+                FileLog.FlushAll();
+
+                currentSettings = new FileLogSettings {FilePath = logFile, FileOpenMode = FileOpenMode.Rewrite};
+                FileLog.RefreshAllSettings();
+
+                WriteMessagesWithTimeout(log, secondMessages, 0);
+            }
+
+            ShouldContainMessages(logFile, secondMessages);
+            ShouldNotContainMessages(logFile, firstMessages);
+        }
+
+        [Test]
+        public void Should_respect_writer_format_setting_updates()
+        {
+            var logFile = Folder.GetFileName("firstLog");
+
+            var firstMessages = GenerateMessages(0, 3);
+            var secondMessages = GenerateMessages(3, 6);
+
+            var currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Default};
+
+            using (var log = new FileLog(() => currentSettings))
+            {
+                WriteMessagesWithTimeout(log, firstMessages, 0);
+
+                FileLog.FlushAll();
+
+                currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Empty};
+                FileLog.RefreshAllSettings();
+
+                WriteMessagesWithTimeout(log, secondMessages, 0);
+            }
+
+            ShouldContainMessages(logFile, firstMessages);
+            ShouldNotContainMessages(logFile, secondMessages);
+        }
+
+        [Test]
+        public void Should_not_reopen_files_if_log_was_disposed()
+        {
+            var logFile = Folder.GetFileName("firstLog");
+
+            var messages = GenerateMessages(0, 3);
+
+            // Let's open file exclusively to ensure that no one else uses it.
+            using (var log = new FileLog(new FileLogSettings {FilePath = logFile, FileShare = FileShare.None}))
+            {
+                WriteMessagesWithTimeout(log, messages, 0);
+            }
+
+            Action assertion = () => System.IO.File.Open(logFile, FileMode.Append, FileAccess.Write, FileShare.None).Close();
+
+            assertion.Should().NotThrow();
+
+            FileLog.RefreshAllSettings();
+
+            assertion.ShouldPassIn(5.Seconds());
+        }
+    }
+}

--- a/Vostok.Logging.File.Tests/Functional/FileLog_CacheAndFlush_Tests.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLog_CacheAndFlush_Tests.cs
@@ -14,7 +14,6 @@ namespace Vostok.Logging.File.Tests.Functional
     [TestFixture]
     internal class FileLog_CacheAndFlush_Tests : FileLogFunctionalTestsBase
     {
-        // TODO: Propagate EnableCache in all tests
         [TestCase(false)]
         [TestCase(true)]
         public void Should_write_to_new_file_after_settings_update(bool cache)
@@ -25,14 +24,14 @@ namespace Vostok.Logging.File.Tests.Functional
             var firstLogMessages = GenerateMessages(0, 3);
             var secondLogMessages = GenerateMessages(3, 6);
 
-            var currentSettings = new FileLogSettings {FilePath = firstLog};
+            var currentSettings = new FileLogSettings {FilePath = firstLog, EnableFileLogSettingsCache = cache};
 
             using (var log = new FileLog(() => currentSettings))
             {
                 WriteMessagesWithTimeout(log, firstLogMessages, 0);
 
                 currentSettings = new FileLogSettings {FilePath = secondLog};
-                FileLog.RefreshAllSettings();
+                log.RefreshSettings();
 
                 WriteMessagesWithTimeout(log, secondLogMessages, 0);
             }
@@ -41,24 +40,25 @@ namespace Vostok.Logging.File.Tests.Functional
             ShouldContainMessages(secondLog, secondLogMessages);
         }
 
-        [Test]
-        public void Should_respect_writer_setting_updates()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_respect_writer_setting_updates(bool cache)
         {
             var logFile = Folder.GetFileName("firstLog");
 
             var firstMessages = GenerateMessages(0, 3);
             var secondMessages = GenerateMessages(3, 6);
 
-            var currentSettings = new FileLogSettings {FilePath = logFile};
+            var currentSettings = new FileLogSettings {FilePath = logFile, EnableFileLogSettingsCache = cache};
 
             using (var log = new FileLog(() => currentSettings))
             {
                 WriteMessagesWithTimeout(log, firstMessages, 0);
 
-                FileLog.FlushAll();
+                log.Flush();
 
-                currentSettings = new FileLogSettings {FilePath = logFile, FileOpenMode = FileOpenMode.Rewrite};
-                FileLog.RefreshAllSettings();
+                currentSettings = new FileLogSettings {FilePath = logFile, FileOpenMode = FileOpenMode.Rewrite, EnableFileLogSettingsCache = cache};
+                log.RefreshSettings();
 
                 WriteMessagesWithTimeout(log, secondMessages, 0);
             }
@@ -67,24 +67,25 @@ namespace Vostok.Logging.File.Tests.Functional
             ShouldNotContainMessages(logFile, firstMessages);
         }
 
-        [Test]
-        public void Should_respect_writer_format_setting_updates()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_respect_writer_format_setting_updates(bool cache)
         {
             var logFile = Folder.GetFileName("firstLog");
 
             var firstMessages = GenerateMessages(0, 3);
             var secondMessages = GenerateMessages(3, 6);
 
-            var currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Default};
+            var currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Default, EnableFileLogSettingsCache = cache};
 
             using (var log = new FileLog(() => currentSettings))
             {
                 WriteMessagesWithTimeout(log, firstMessages, 0);
 
-                FileLog.FlushAll();
+                log.Flush();
 
-                currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Empty};
-                FileLog.RefreshAllSettings();
+                currentSettings = new FileLogSettings {FilePath = logFile, OutputTemplate = OutputTemplate.Empty, EnableFileLogSettingsCache = cache};
+                log.RefreshSettings();
 
                 WriteMessagesWithTimeout(log, secondMessages, 0);
             }
@@ -93,15 +94,16 @@ namespace Vostok.Logging.File.Tests.Functional
             ShouldNotContainMessages(logFile, secondMessages);
         }
 
-        [Test]
-        public void Should_not_reopen_files_if_log_was_disposed()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_not_reopen_files_if_log_was_disposed(bool cache)
         {
             var logFile = Folder.GetFileName("firstLog");
 
             var messages = GenerateMessages(0, 3);
-
+            var log = new FileLog(new FileLogSettings {FilePath = logFile, FileShare = FileShare.None, EnableFileLogSettingsCache = cache});
             // Let's open file exclusively to ensure that no one else uses it.
-            using (var log = new FileLog(new FileLogSettings {FilePath = logFile, FileShare = FileShare.None}))
+            using (log)
             {
                 WriteMessagesWithTimeout(log, messages, 0);
             }
@@ -110,7 +112,7 @@ namespace Vostok.Logging.File.Tests.Functional
 
             assertion.Should().NotThrow();
 
-            FileLog.RefreshAllSettings();
+            log.RefreshSettings();
 
             assertion.ShouldPassIn(5.Seconds());
         }

--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -109,7 +109,7 @@ namespace Vostok.Logging.File.Configuration
 
         /// <summary>
         /// <para>Enables internal <see cref="FileLogSettings"/> cache in order to reduce overhead of frequent provider calls.</para>
-        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettingsAsync"/> static method.</para>
+        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettings"/> static method.</para>
         /// <para>Dynamic reconfiguration is not supported for this parameter: a snapshot will be taken on first usage attempt.</para>
         /// </summary>
         public bool EnableFileLogSettingsCache { get; set; } = true;
@@ -117,7 +117,7 @@ namespace Vostok.Logging.File.Configuration
         /// <summary>
         /// <para>Cooldown for enforcing file-related settings (name, rolling strategy, buffer size, etc.). This means that when conditions are met to switch to the next part of log file or reopen the file with another name/options due to change in settings, the switching may be delayed for up to <see cref="FileSettingsUpdateCooldown"/>.</para>
         /// <para>If <see cref="EnableFileLogSettingsCache"/> is true file-related settings update may be delayed for a longer time.</para>
-        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettingsAsync"/> static method.</para>
+        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettings"/> static method.</para>
         /// <para>Dynamic reconfiguration is supported for this parameter: <see cref="FileLog"/> will react to its changes.</para>
         /// </summary>
         public TimeSpan FileSettingsUpdateCooldown { get; set; } = TimeSpan.FromSeconds(1);

--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -106,6 +106,7 @@ namespace Vostok.Logging.File.Configuration
         /// </summary>
         public int EventsBufferCapacity { get; set; } = 10 * 1000;
 
+        // TODO: Propagate file settings update cooldown?
         /// <summary>
         /// <para>Cooldown for enforcing file-related settings (name, rolling strategy, buffer size, etc.). This means that when conditions are met to switch to the next part of log file or reopen the file with another name/options due to change in settings, the switching may be delayed for up to <see cref="FileSettingsUpdateCooldown"/>.</para>
         /// <para>Dynamic reconfiguration is supported for this parameter: <see cref="FileLog"/> will react to its changes.</para>

--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -107,15 +107,16 @@ namespace Vostok.Logging.File.Configuration
         /// </summary>
         public int EventsBufferCapacity { get; set; } = 10 * 1000;
 
-
         /// <summary>
         /// <para>Enables internal <see cref="FileLogSettings"/> cache in order to reduce overhead of frequent provider calls.</para>
+        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettingsAsync"/> static method.</para>
         /// <para>Dynamic reconfiguration is not supported for this parameter: a snapshot will be taken on first usage attempt.</para>
         /// </summary>
         public bool EnableFileLogSettingsCache { get; set; } = true;
 
         /// <summary>
         /// <para>Cooldown for enforcing file-related settings (name, rolling strategy, buffer size, etc.). This means that when conditions are met to switch to the next part of log file or reopen the file with another name/options due to change in settings, the switching may be delayed for up to <see cref="FileSettingsUpdateCooldown"/>.</para>
+        /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettingsAsync"/> static method.</para>
         /// <para>Dynamic reconfiguration is supported for this parameter: <see cref="FileLog"/> will react to its changes.</para>
         /// </summary>
         public TimeSpan FileSettingsUpdateCooldown { get; set; } = TimeSpan.FromSeconds(1);

--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -116,6 +116,7 @@ namespace Vostok.Logging.File.Configuration
 
         /// <summary>
         /// <para>Cooldown for enforcing file-related settings (name, rolling strategy, buffer size, etc.). This means that when conditions are met to switch to the next part of log file or reopen the file with another name/options due to change in settings, the switching may be delayed for up to <see cref="FileSettingsUpdateCooldown"/>.</para>
+        /// <para>If <see cref="EnableFileLogSettingsCache"/> is true file-related settings update may be delayed for a longer time.</para>
         /// <para>One have an option to refresh settings immediately through <see cref="FileLog.RefreshAllSettingsAsync"/> static method.</para>
         /// <para>Dynamic reconfiguration is supported for this parameter: <see cref="FileLog"/> will react to its changes.</para>
         /// </summary>

--- a/Vostok.Logging.File/Configuration/FileLogSettings.cs
+++ b/Vostok.Logging.File/Configuration/FileLogSettings.cs
@@ -107,7 +107,7 @@ namespace Vostok.Logging.File.Configuration
         /// </summary>
         public int EventsBufferCapacity { get; set; } = 10 * 1000;
 
-        // TODO: Propagate file settings update cooldown?
+
         /// <summary>
         /// <para>Enables internal <see cref="FileLogSettings"/> cache in order to reduce overhead of frequent provider calls.</para>
         /// <para>Dynamic reconfiguration is not supported for this parameter: a snapshot will be taken on first usage attempt.</para>

--- a/Vostok.Logging.File/Configuration/SafeSettingsCache.cs
+++ b/Vostok.Logging.File/Configuration/SafeSettingsCache.cs
@@ -9,7 +9,7 @@ namespace Vostok.Logging.File.Configuration
         private static readonly object CooldownGuard = new object();
 
         private readonly SafeSettingsProvider provider;
-        private readonly TimeSpan ttl = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan ttl;
         private readonly bool enabled;
 
         private volatile object updateCooldown;
@@ -23,6 +23,7 @@ namespace Vostok.Logging.File.Configuration
             var settings = Get();
 
             enabled = settings.EnableFileLogSettingsCache;
+            ttl = settings.FileSettingsUpdateCooldown;
 
             if (enabled)
                 currentSettings = settings;

--- a/Vostok.Logging.File/Configuration/SafeSettingsCache.cs
+++ b/Vostok.Logging.File/Configuration/SafeSettingsCache.cs
@@ -9,7 +9,7 @@ namespace Vostok.Logging.File.Configuration
         private static readonly object CooldownGuard = new object();
 
         private readonly SafeSettingsProvider provider;
-        private readonly TimeSpan ttl;
+        private readonly TimeSpan ttl = TimeSpan.FromSeconds(1);
         private readonly bool enabled;
 
         private volatile object updateCooldown;
@@ -23,7 +23,6 @@ namespace Vostok.Logging.File.Configuration
             var settings = Get();
 
             enabled = settings.EnableFileLogSettingsCache;
-            ttl = settings.FileSettingsUpdateCooldown;
 
             if (enabled)
                 currentSettings = settings;

--- a/Vostok.Logging.File/EventsWriting/CooldownController.cs
+++ b/Vostok.Logging.File/EventsWriting/CooldownController.cs
@@ -8,7 +8,7 @@ namespace Vostok.Logging.File.EventsWriting
     internal class CooldownController : ICooldownController
     {
         private readonly Signal endImmediately = new Signal(false);
-        private Task cooldownTask = Task.FromResult(Task.CompletedTask);
+        private Task cooldownTask = Task.CompletedTask;
 
         public bool IsCool => cooldownTask.IsCompleted;
 

--- a/Vostok.Logging.File/EventsWriting/CooldownController.cs
+++ b/Vostok.Logging.File/EventsWriting/CooldownController.cs
@@ -1,18 +1,28 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Signal = System.Threading.Tasks.TaskCompletionSource<bool>;
 
 namespace Vostok.Logging.File.EventsWriting
 {
     internal class CooldownController : ICooldownController
     {
+        private Signal endImmediately = new Signal();
         private Task cooldownTask = Task.CompletedTask;
 
         public bool IsCool => cooldownTask.IsCompleted;
 
-        public Task WaitForCooldownAsync() => cooldownTask;
+        public Task WaitForCooldownAsync() => Task.WhenAny(cooldownTask, endImmediately.Task);
 
-        public void IncurCooldown(TimeSpan duration, CancellationToken cancellation) =>
+        public void IncurCooldown(TimeSpan duration, CancellationToken cancellation)
+        {
+            endImmediately = new Signal();
             cooldownTask = Task.Delay(duration, cancellation);
+        }
+
+        public void DropCooldown()
+        {
+            endImmediately.SetResult(true);
+        }
     }
 }

--- a/Vostok.Logging.File/EventsWriting/CooldownController.cs
+++ b/Vostok.Logging.File/EventsWriting/CooldownController.cs
@@ -8,16 +8,16 @@ namespace Vostok.Logging.File.EventsWriting
     internal class CooldownController : ICooldownController
     {
         private readonly Signal endImmediately = new Signal(false);
-        private Task cooldownTask = Task.CompletedTask;
+        private Task cooldownTask = Task.FromResult(Task.CompletedTask);
 
         public bool IsCool => cooldownTask.IsCompleted;
 
-        public Task WaitForCooldownAsync() => Task.WhenAny(cooldownTask, endImmediately);
+        public Task WaitForCooldownAsync() => cooldownTask;
 
         public void IncurCooldown(TimeSpan duration, CancellationToken cancellation)
         {
             endImmediately.Reset();
-            cooldownTask = Task.Delay(duration, cancellation);
+            cooldownTask = Task.WhenAny(Task.Delay(duration, cancellation), endImmediately.WaitAsync(cancellation)).Unwrap();
         }
 
         public void DropCooldown() => endImmediately.Set();

--- a/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
+++ b/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
@@ -70,6 +70,8 @@ namespace Vostok.Logging.File.EventsWriting
             return cache.writer;
         }
 
+        public void DropCooldown() => cooldownController.DropCooldown();
+
         public void Dispose()
         {
             cache.writer?.Dispose();

--- a/Vostok.Logging.File/EventsWriting/ICooldownController.cs
+++ b/Vostok.Logging.File/EventsWriting/ICooldownController.cs
@@ -11,5 +11,7 @@ namespace Vostok.Logging.File.EventsWriting
         Task WaitForCooldownAsync();
 
         void IncurCooldown(TimeSpan duration, CancellationToken cancellation);
+
+        void DropCooldown();
     }
 }

--- a/Vostok.Logging.File/EventsWriting/IEventsWriterProvider.cs
+++ b/Vostok.Logging.File/EventsWriting/IEventsWriterProvider.cs
@@ -14,5 +14,7 @@ namespace Vostok.Logging.File.EventsWriting
         /// </summary>
         [ItemCanBeNull]
         Task<IEventsWriter> ObtainWriterAsync(CancellationToken cancellation);
+
+        void DropCooldown();
     }
 }

--- a/Vostok.Logging.File/FileLog.cs
+++ b/Vostok.Logging.File/FileLog.cs
@@ -235,6 +235,8 @@ namespace Vostok.Logging.File
                 muxerRegistration?.Dispose();
                 muxerRegistration = null;
             }
+
+            Instances.Remove(this);
         }
 
         private IMuxerRegistration ObtainMuxerRegistration(FilePath file, FileLogSettings settings)

--- a/Vostok.Logging.File/FileLog.cs
+++ b/Vostok.Logging.File/FileLog.cs
@@ -28,6 +28,7 @@ namespace Vostok.Logging.File
     public class FileLog : ILog, IDisposable
     {
         private static readonly MultiFileMuxer DefaultMuxer;
+        private static readonly WeakSet<FileLog> Instances;
 
         private readonly IMultiFileMuxer muxer;
         private readonly object muxerRegistrationLock;
@@ -42,8 +43,13 @@ namespace Vostok.Logging.File
 
         static FileLog()
         {
+            var cleanupPeriod = TimeSpan.FromSeconds(5);
+            
             DefaultMuxer = new MultiFileMuxer(new SingleFileMuxerFactory());
-            DefaultMuxer.InitiateOrphanedRegistrationsCleanup(TimeSpan.FromSeconds(5));
+            DefaultMuxer.InitiateOrphanedRegistrationsCleanup(cleanupPeriod);
+
+            Instances = new WeakSet<FileLog>();
+            Instances.InitiatePurge(cleanupPeriod);
         }
 
         /// <summary>

--- a/Vostok.Logging.File/FileLog.cs
+++ b/Vostok.Logging.File/FileLog.cs
@@ -132,9 +132,9 @@ namespace Vostok.Logging.File
         public static void FlushAll() => FlushAllAsync().GetAwaiter().GetResult();
 
         /// <summary>
-        /// Refreshes all caches from all FileLog instances asynchronously. Throws in case of error in any of them.
+        /// Refreshes all caches from all FileLog instances asynchronously. Throws in case of error in any of them (propagates all errors that may occur during settings update).
         /// </summary>
-        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
+        /// <exception cref="FileLogException"></exception>
         public static Task RefreshAllSettingsAsync() => Task.WhenAll(
             Instances
                .Select(
@@ -144,9 +144,9 @@ namespace Vostok.Logging.File
         );
 
         /// <summary>
-        /// Refreshes all caches from all FileLog instances. Throws in case of error in any of them.
+        /// Refreshes all caches from all FileLog instances. Throws in case of error in any of them (propagates all errors that may occur during settings update). 
         /// </summary>
-        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
+        /// <exception cref="FileLogException"></exception>
         public static void RefreshAllSettings() => RefreshAllSettingsAsync().GetAwaiter().GetResult();
 
         /// <inheritdoc />
@@ -204,21 +204,20 @@ namespace Vostok.Logging.File
         public void Flush() => FlushAsync().GetAwaiter().GetResult();
 
         /// <summary>
-        /// Refreshes all caches asynchronously. Throws in case of error.
+        /// Refreshes all caches asynchronously. Throws in case of error (propagates all errors that may occur during settings update).
         /// </summary>
-        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
+        /// <exception cref="FileLogException"></exception>
         public Task RefreshSettingsAsync()
         {
-            // This is the method from other PR. 
-            // settingsProvider.ForceRefresh();
+            settingsProvider.ForceRefresh();
 
             return muxer.RefreshSettingsAsync();
         }
 
         /// <summary>
-        /// Refreshes all caches. Throws in case of error.
+        /// Refreshes all caches. Throws in case of error (propagates all errors that may occur during settings update).
         /// </summary>
-        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
+        /// <exception cref="FileLogException"></exception>
         public void RefreshSettings() => RefreshSettingsAsync().GetAwaiter().GetResult();
 
         /// <inheritdoc />

--- a/Vostok.Logging.File/FileLog.cs
+++ b/Vostok.Logging.File/FileLog.cs
@@ -80,7 +80,8 @@ namespace Vostok.Logging.File
         /// <para>These settings are set on per-file level (rather than per-instance). Only the first <see cref="FileLog"/> to log something to a file will be allowed to modify settings for that file.</para>
         /// </description></item>
         /// <item><description>
-        /// <para>All other settings can be changed any time and come into effect immediately.</para> // TODO
+        /// <para>All other settings can be changed any time and come into effect after some time.</para>
+        /// <para>In case of need of urgent settings refresh there is a <see cref="FileLog.RefreshAllSettings"/> static method.</para>
         /// </description></item>
         /// </list>
         /// </summary>
@@ -129,7 +130,10 @@ namespace Vostok.Logging.File
         /// <exception cref="FileLogException">Unable to flush events to at least one of the files.</exception>
         public static void FlushAll() => FlushAllAsync().GetAwaiter().GetResult();
 
-        // TODO: Add doc
+        /// <summary>
+        /// Refreshes all caches from all FileLog instances asynchronously. Throws in case of error in any of them.
+        /// </summary>
+        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
         public static Task RefreshAllSettingsAsync() => Task.WhenAll(
             Instances
                .Select(
@@ -138,7 +142,10 @@ namespace Vostok.Logging.File
                         : Task.CompletedTask)
         );
 
-        // TODO: Add doc
+        /// <summary>
+        /// Refreshes all caches from all FileLog instances. Throws in case of error in any of them.
+        /// </summary>
+        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
         public static void RefreshAllSettings() => RefreshAllSettingsAsync().GetAwaiter().GetResult();
 
         /// <inheritdoc />
@@ -192,7 +199,10 @@ namespace Vostok.Logging.File
         /// <exception cref="FileLogException">Unable to flush events to the file.</exception>
         public void Flush() => FlushAsync().GetAwaiter().GetResult();
 
-        // TODO: Add doc
+        /// <summary>
+        /// Refreshes all caches asynchronously. Throws in case of error.
+        /// </summary>
+        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
         public Task RefreshSettingsAsync()
         {
             // This is the method from other PR. 
@@ -201,7 +211,10 @@ namespace Vostok.Logging.File
             return muxer.RefreshSettingsAsync();
         }
 
-        // TODO: Add doc
+        /// <summary>
+        /// Refreshes all caches. Throws in case of error.
+        /// </summary>
+        /// <exception cref="FileLogException"></exception> // TODO: make sure what exceptions are possible and list them here.
         public void RefreshSettings() => RefreshSettingsAsync().GetAwaiter().GetResult();
 
         /// <inheritdoc />

--- a/Vostok.Logging.File/FileLog.cs
+++ b/Vostok.Logging.File/FileLog.cs
@@ -74,7 +74,7 @@ namespace Vostok.Logging.File
         /// <para>These settings are set on per-file level (rather than per-instance). Only the first <see cref="FileLog"/> to log something to a file will be allowed to modify settings for that file.</para>
         /// </description></item>
         /// <item><description>
-        /// <para>All other settings can be changed any time and come into effect immediately.</para>
+        /// <para>All other settings can be changed any time and come into effect immediately.</para> // TODO
         /// </description></item>
         /// </list>
         /// </summary>

--- a/Vostok.Logging.File/Helpers/WeakSet.cs
+++ b/Vostok.Logging.File/Helpers/WeakSet.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vostok.Logging.File.Helpers
+{
+    internal class WeakSet<T> : IEnumerable<WeakReference<T>>
+        where T : class
+    {
+        private readonly object guard = new object();
+        private HashSet<WeakReference<T>> references = new HashSet<WeakReference<T>>();
+
+        public void Add(T target)
+        {
+            lock (guard)
+                references.Add(new WeakReference<T>(target));
+        }
+
+        public void Remove(T target)
+        {
+            lock (guard)
+                references.Remove(new WeakReference<T>(target));
+        }
+
+        public void Purge()
+        {
+            var newSet = new HashSet<WeakReference<T>>();
+
+            foreach (var reference in this.Where(reference => reference.TryGetTarget(out _)))
+                newSet.Add(reference);
+
+            lock (guard)
+                references = newSet;
+        }
+
+        public IEnumerator<WeakReference<T>> GetEnumerator()
+        {
+            List<WeakReference<T>> snapshot;
+
+            lock (guard)
+                snapshot = references.ToList();
+
+            return snapshot.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+    }
+}

--- a/Vostok.Logging.File/Helpers/WeakSet.cs
+++ b/Vostok.Logging.File/Helpers/WeakSet.cs
@@ -52,11 +52,13 @@ namespace Vostok.Logging.File.Helpers
         {
             var newSet = new HashSet<WeakReference<T>>();
 
-            foreach (var reference in this.Where(reference => reference.TryGetTarget(out _)))
-                newSet.Add(reference);
-
             lock (guard)
+            {
+                foreach (var reference in this.Where(reference => reference.TryGetTarget(out _)))
+                    newSet.Add(reference);
+
                 references = newSet;
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator() =>

--- a/Vostok.Logging.File/Helpers/WeakSet.cs
+++ b/Vostok.Logging.File/Helpers/WeakSet.cs
@@ -10,7 +10,7 @@ namespace Vostok.Logging.File.Helpers
         where T : class
     {
         private readonly object guard = new object();
-        private HashSet<WeakReference<T>> references = new HashSet<WeakReference<T>>();
+        private readonly HashSet<WeakReference<T>> references = new HashSet<WeakReference<T>>();
 
         public void Add(T target)
         {
@@ -50,15 +50,8 @@ namespace Vostok.Logging.File.Helpers
 
         private void Purge()
         {
-            var newSet = new HashSet<WeakReference<T>>();
-
             lock (guard)
-            {
-                foreach (var reference in this.Where(reference => reference.TryGetTarget(out _)))
-                    newSet.Add(reference);
-
-                references = newSet;
-            }
+                references.RemoveWhere(reference => !reference.TryGetTarget(out _));
         }
 
         IEnumerator IEnumerable.GetEnumerator() =>

--- a/Vostok.Logging.File/Muxers/IMultiFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/IMultiFileMuxer.cs
@@ -19,5 +19,7 @@ namespace Vostok.Logging.File.Muxers
             [NotNull] WeakReference initiator);
 
         Task FlushAsync([NotNull] FilePath file);
+        
+        Task RefreshSettingsAsync();
     }
 }

--- a/Vostok.Logging.File/Muxers/ISingleFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/ISingleFileMuxer.cs
@@ -11,5 +11,7 @@ namespace Vostok.Logging.File.Muxers
         bool TryAdd([NotNull] LogEventInfo info, bool fromOwner);
 
         Task FlushAsync();
+
+        Task RefreshSettingsAsync();
     }
 }

--- a/Vostok.Logging.File/Muxers/MultiFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/MultiFileMuxer.cs
@@ -32,6 +32,8 @@ namespace Vostok.Logging.File.Muxers
         public Task FlushAsync(FilePath file) =>
             states.TryGetValue(file, out var state) ? state.Muxer.FlushAsync() : Task.CompletedTask;
 
+        public Task RefreshSettingsAsync() => Task.WhenAll(states.Select(pair => pair.Value.Muxer.RefreshSettingsAsync()));
+
         public Task FlushAsync() =>
             Task.WhenAll(states.Select(pair => pair.Value.Muxer.FlushAsync()));
 

--- a/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
@@ -124,6 +124,13 @@ namespace Vostok.Logging.File.Muxers
                 throw new FileLogException($"Failed to flush log events to file '{settings.FilePath}'.");
         }
 
+        public Task RefreshSettingsAsync()
+        {
+            writerProvider.DropCooldown();
+            
+            return FlushAsync();
+        }
+
         private static void SignalFlushWaiters(IEnumerable<Waiter> waiters, bool result)
         {
             foreach (var waiter in waiters)

--- a/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
@@ -128,7 +128,7 @@ namespace Vostok.Logging.File.Muxers
         {
             writerProvider.DropCooldown();
 
-            // NOTE: We have to flush all events so that event writer refreshes it's settings
+            // NOTE: We have to flush all events so that event writer refreshes its settings
             // because if event writer is currently processing some events with old settings, then new events that are
             // put to the bounded queue will be processed with old settings as well.
             return FlushAsync();

--- a/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
@@ -128,6 +128,9 @@ namespace Vostok.Logging.File.Muxers
         {
             writerProvider.DropCooldown();
 
+            // NOTE: We have to flush all events so that event writer refreshes it's settings
+            // because if event writer is currently processing some events with old settings, then new events that are
+            // put to the bounded queue will be processed with old settings as well.
             return FlushAsync();
         }
 

--- a/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
+++ b/Vostok.Logging.File/Muxers/SingleFileMuxer.cs
@@ -127,7 +127,7 @@ namespace Vostok.Logging.File.Muxers
         public Task RefreshSettingsAsync()
         {
             writerProvider.DropCooldown();
-            
+
             return FlushAsync();
         }
 


### PR DESCRIPTION
We needed a trigger to refresh three types of cache:
1. Cache in IEventsWriterProvider
2. Cache in SafeSettingsProvider
3. Cache in SafeSettingsCache (#19)

The first one can be easily refreshed propagating DropCooldown methods to muxers. We are able to refresh 1st type cache using static method since we have access to static muxer.

The problem is that we are not able to refresh 2nd and 3rd cache types because we should have a trigger to refresh their settings (but they are individual per `FileLog` instance).

I see two ways to handle this problem:
1. Signal (Resubscription-like)

      We can create task completion source so that every `FileLog` can subscribe to that signal (i.e. through `ContinueWith`).
      There is a problem that we should not only trigger tasks, but we also need to wait for their completion.
      The only solution to this problem that I see is that we should accumulate tasks somehow in order to have something awaitable. (Do we really need a signal then?)
      
      Cons:
      Thundering herd problem occurs when we want to store tasks after refreshment because every instance tries to subscribe again. (Because TaskCompletionSource is not reusable and you have to either keep a collection of subscribers or resubscribe after every refresh).
 
 2. Set of weak references (Keep a collection of subscribers)

       We can store weak references of `FileLog`s in a weak set. If we need to refresh settings we can just iterate over a set of instances and extract a task from each one. Simple.
      
      Pros:
      No thundering herd problem
      
      Cons:
      We have to accumulate references and clean them from time to time.

In this PR I implemented second approach which I believe is cheaper but it's not a problem to switch to the first one.