### PR TITLE
Add reopen file if it was deleted during the logger work

### DIFF
--- a/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
@@ -160,7 +160,7 @@ namespace Vostok.Logging.File.Tests.Functional
                 log.Info(FormatMessage(0));
                 await FileLog.FlushAllAsync();
                 System.IO.File.Delete(logName);
-                await Task.Delay(10);
+                await Task.Delay(20);
                 log.Info(FormatMessage(1));
             }
 

--- a/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
@@ -153,7 +153,7 @@ namespace Vostok.Logging.File.Tests.Functional
                        new FileLogSettings
                        {
                            FilePath = logName,
-                           FileShare = FileShare.Delete,
+                           FileShare = FileShare.Delete | FileShare.ReadWrite,
                            FileSettingsUpdateCooldown = TimeSpan.FromMilliseconds(1)
                        }))
             {

--- a/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
+++ b/Vostok.Logging.File.Tests/Functional/FileLog_Tests.cs
@@ -143,7 +143,31 @@ namespace Vostok.Logging.File.Tests.Functional
             logText.Should().NotContain(FormatMessage(0));
             logText.Should().Contain(FormatMessage(1));
         }
-        
+
+        [Test]
+        public async Task Should_reopen_file_if_it_was_deleted()
+        {
+            var logName = Folder.GetFileName("log");
+
+            using (var log = new FileLog(
+                       new FileLogSettings
+                       {
+                           FilePath = logName,
+                           FileShare = FileShare.Delete,
+                           FileSettingsUpdateCooldown = TimeSpan.FromMilliseconds(1)
+                       }))
+            {
+                log.Info(FormatMessage(0));
+                await FileLog.FlushAllAsync();
+                System.IO.File.Delete(logName);
+                await Task.Delay(10);
+                log.Info(FormatMessage(1));
+            }
+
+            System.IO.File.Exists(logName).Should().BeTrue();
+            ShouldContainMessage(logName, FormatMessage(1));
+        }
+
         [Test]
         public void Should_create_directories_leading_to_log_file_path_if_needed()
         {

--- a/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
+++ b/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
@@ -57,7 +57,7 @@ namespace Vostok.Logging.File.EventsWriting
                     if (currentFile != cache.file || 
                         ShouldReopenWriter(cache.settings, settings) || 
                         cache.writer == null || 
-                        (settings.FileShare == FileShare.Delete && System.IO.File.Exists(currentFile.NormalizedPath) == false))
+                        (settings.FileShare.HasFlag(FileShare.Delete) && System.IO.File.Exists(currentFile.NormalizedPath) == false))
                     {
                         cache.writer?.Dispose();
                         cache.writer = null;

--- a/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
+++ b/Vostok.Logging.File/EventsWriting/EventsWriterProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,7 +54,10 @@ namespace Vostok.Logging.File.EventsWriting
                     var rollingStrategy = rollingStrategyProvider.ObtainStrategy();
 
                     var currentFile = rollingStrategy.GetCurrentFile(basePath);
-                    if (currentFile != cache.file || ShouldReopenWriter(cache.settings, settings) || cache.writer == null)
+                    if (currentFile != cache.file || 
+                        ShouldReopenWriter(cache.settings, settings) || 
+                        cache.writer == null || 
+                        (settings.FileShare == FileShare.Delete && System.IO.File.Exists(currentFile.NormalizedPath) == false))
                     {
                         cache.writer?.Dispose();
                         cache.writer = null;


### PR DESCRIPTION
Added a file existence check if all previous conditions have passed and the `FileShare` enum contains the `Delete` flag.

Given that checking the conditions and updating the settings can only occur at `UpdateCooldown` intervals, there is a risk that part of the logs in this interval may be lost when the file is deleted. However, I think it's better than not writing anything down at all.

Of course, it is possible to take this check outside the condition `(cooldownController.IsCool)`, but I believe that this will negatively affect performance because the check will occur with each entry in the log